### PR TITLE
feat: Add delete previous and delete next functionalities

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ path/to/cliphist-rofi
 
 It will show by default all non-binary cliphist entries. You can switch between
 text/image mode by using `Alt-t` / `Alt-i` and also delete entries using
-`Alt-d`.
+`Alt-d`, `Alt-p` (delete previous) and `Alt-n` (delete next).
 
 ![Text Mode](./img/text-mode.png)
 
@@ -106,4 +106,14 @@ description = "Switch to image mode!"
 title = "Delete"
 shortcut = "Alt+d"
 description = "Delete entry"
+
+[delete_previous_config]
+title = "Delete previous"
+shortcut = "Alt+p"
+description = "Delete all entries before the selected one"
+
+[delete_next_config]
+title = "Delete next"
+shortcut = "Alt+n"
+description = "Delete all entries after the selected one"
 ```

--- a/src/bin/rofi-cliphist.rs
+++ b/src/bin/rofi-cliphist.rs
@@ -75,6 +75,8 @@ fn main() -> anyhow::Result<()> {
         cfg.text_mode_config,
         cfg.image_mode_config,
         cfg.delete_mode_config,
+        cfg.delete_previous_config,
+        cfg.delete_next_config,
     )?
     .run()
 }

--- a/src/bin/rofi-cliphist.rs
+++ b/src/bin/rofi-cliphist.rs
@@ -38,7 +38,7 @@ fn main() -> anyhow::Result<()> {
     simple_logger::init_with_level(args.verbose.log_level().unwrap_or(Level::Error))?;
 
     let mut cfg = if let Some(config_path) = &args.config {
-        info!("Using custom config file: {:?}", config_path);
+        info!("Using custom config file: {config_path:?}");
         config::load(config_path).expect("Error loading config file")
     } else {
         match config::load_default() {

--- a/src/bin/rofi-cliphist.rs
+++ b/src/bin/rofi-cliphist.rs
@@ -72,11 +72,13 @@ fn main() -> anyhow::Result<()> {
         cache,
         cliphist,
         clipboard,
-        cfg.text_mode_config,
-        cfg.image_mode_config,
-        cfg.delete_mode_config,
-        cfg.delete_previous_config,
-        cfg.delete_next_config,
+        rofi::cliphist_mode::ClipHistModeConfig {
+            text_mode: cfg.text_mode_config,
+            image_mode: cfg.image_mode_config,
+            delete_mode: cfg.delete_mode_config,
+            delete_previous_mode: cfg.delete_previous_config,
+            delete_next_mode: cfg.delete_next_config,
+        },
     )?
     .run()
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -20,7 +20,7 @@ impl SimpleCache {
     /// Create a new SimpleCache instance on $XDG_CACHE_DIR/hierarchy.
     /// Where `whierarchy` is a valid unix-like path.
     pub fn new(hierarchy: &str) -> anyhow::Result<Self> {
-        trace!("Creating cache directory for hierarchy: {}", hierarchy);
+        trace!("Creating cache directory for hierarchy: {hierarchy}");
 
         Ok(Self {
             cache_dir: Self::init_cache_dir(hierarchy)?,
@@ -29,7 +29,7 @@ impl SimpleCache {
 
     /// Prune the cache directory, removing all files that are not in the `excludes` list.
     pub fn prune(&self, excludes: Vec<String>) -> anyhow::Result<usize> {
-        trace!("Pruning cache directory, excluding: {:?}", excludes);
+        trace!("Pruning cache directory, excluding: {excludes:?}");
 
         let to_delete = fs::read_dir(&self.cache_dir)
             .context(format!("Error reading cache folder: {:?}", self.cache_dir))?
@@ -77,7 +77,7 @@ impl SimpleCache {
 
     /// Initialize the cache directory, creating the folders if they don't exist.
     fn init_cache_dir(hierarchy: &str) -> anyhow::Result<PathBuf> {
-        trace!("Initializing cache directory for hierarchy: {}", hierarchy);
+        trace!("Initializing cache directory for hierarchy: {hierarchy}");
         let dirs =
             BaseDirs::new().ok_or_else(|| anyhow::anyhow!("Error getting base directories"))?;
 
@@ -87,7 +87,7 @@ impl SimpleCache {
 
         if let Ok(false) = fs::exists(cache_dir) {
             fs::create_dir_all(cache_dir)
-                .context(format!("Error creating cache folder: {:?}", cache_dir))?;
+                .context(format!("Error creating cache folder: {cache_dir:?}"))?;
         }
 
         Ok(cache_dir.to_path_buf())

--- a/src/cliphist.rs
+++ b/src/cliphist.rs
@@ -65,7 +65,7 @@ impl ClipHist {
 
     /// Remove an entry from the clipboard history.
     pub fn remove(&self, id: String) -> anyhow::Result<()> {
-        debug!("About to remove entry with id: {}", id);
+        debug!("About to remove entry with id: {id}");
         let mut child = Command::new(&self.bin)
             .arg("delete")
             .stdin(Stdio::piped())
@@ -87,14 +87,14 @@ impl ClipHist {
             bail!("Error executing cliphist");
         }
 
-        debug!("Successfully removed entry with id: {}", id);
+        debug!("Successfully removed entry with id: {id}");
 
         Ok(())
     }
 
     /// Get the value of a given entry in the clipboard history.
     pub fn value_of(&self, id: String) -> anyhow::Result<Vec<u8>> {
-        trace!("Getting value of entry with id: {}", id);
+        trace!("Getting value of entry with id: {id}");
 
         let value = Command::new(&self.bin)
             .arg("decode")
@@ -147,7 +147,7 @@ impl CacheEntry for ClipHistEntry {
     fn id(&self) -> String {
         match self {
             ClipHistEntry::Text { id, .. } => id.to_string(),
-            ClipHistEntry::Image { id, content_type } => format!("{}.{}", id, content_type),
+            ClipHistEntry::Image { id, content_type } => format!("{id}.{content_type}"),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,6 @@ pub struct Config {
     pub delete_previous_config: ModeConfig,
     #[serde(default = "default_delete_next_config")]
     pub delete_next_config: ModeConfig,
-    
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -158,5 +157,3 @@ fn default_delete_next_config() -> ModeConfig {
         description: "Delete all entries after the selected one".to_string(),
     }
 }
-
-

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,11 @@ pub struct Config {
     pub text_mode_config: ModeConfig,
     #[serde(default = "default_delete_mode_config")]
     pub delete_mode_config: ModeConfig,
+    #[serde(default = "default_delete_previous_config")]
+    pub delete_previous_config: ModeConfig,
+    #[serde(default = "default_delete_next_config")]
+    pub delete_next_config: ModeConfig,
+    
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -84,6 +89,8 @@ impl Default for Config {
                 shortcut: "Alt+d".to_string(),
                 description: "Delete entry".to_string(),
             },
+            delete_previous_config: default_delete_previous_config(),
+            delete_next_config: default_delete_next_config(),
         }
     }
 }
@@ -123,7 +130,7 @@ fn default_image_mode_config() -> ModeConfig {
 fn default_text_mode_config() -> ModeConfig {
     ModeConfig {
         title: "Texts".to_string(),
-        shortcut: "Alt+d".to_string(),
+        shortcut: "Alt+t".to_string(),
         description: "Switch to text".to_string(),
     }
 }
@@ -135,3 +142,21 @@ fn default_delete_mode_config() -> ModeConfig {
         description: "Delete entry".to_string(),
     }
 }
+
+fn default_delete_previous_config() -> ModeConfig {
+    ModeConfig {
+        title: "Delete previous".to_string(),
+        shortcut: "Alt+p".to_string(),
+        description: "Delete all entries before the selected one".to_string(),
+    }
+}
+
+fn default_delete_next_config() -> ModeConfig {
+    ModeConfig {
+        title: "Delete next".to_string(),
+        shortcut: "Alt+n".to_string(),
+        description: "Delete all entries after the selected one".to_string(),
+    }
+}
+
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,7 +50,7 @@ pub struct ModeConfig {
 
 /// Load configuration from a file
 pub fn load(path: &PathBuf) -> anyhow::Result<Config> {
-    debug!("Loading config from file: {:?}", path);
+    debug!("Loading config from file: {path:?}");
 
     let config = fs::read_to_string(path).context("Error reading config file")?;
     toml::from_str(&config).context("Error parsing config file")

--- a/src/rofi.rs
+++ b/src/rofi.rs
@@ -183,7 +183,10 @@ impl Rofi {
             .spawn()
             .context("Error executing rofi")?;
 
-        debug!("Executing rofi with command: {:?} {:?}", &self.bin, &options);
+        debug!(
+            "Executing rofi with command: {:?} {:?}",
+            &self.bin, &options
+        );
 
         if let Some(mut writer) = process.stdin.take() {
             for entry in entries {

--- a/src/rofi.rs
+++ b/src/rofi.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::Context;
-use log::trace;
+use log::{debug, trace};
 
 use crate::{cache, cliphist::ClipHistEntry};
 
@@ -179,9 +179,11 @@ impl Rofi {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .args(options)
+            .args(&options)
             .spawn()
             .context("Error executing rofi")?;
+
+        debug!("Executing rofi with command: {:?} {:?}", &self.bin, &options);
 
         if let Some(mut writer) = process.stdin.take() {
             for entry in entries {

--- a/src/rofi.rs
+++ b/src/rofi.rs
@@ -127,7 +127,7 @@ impl From<&RofiOptions> for Vec<String> {
             options.push(format.into());
         }
         for KbCustom { key, shortcut, .. } in &val.custom_kbs {
-            options.push(format!("-kb-custom-{}", key));
+            options.push(format!("-kb-custom-{key}"));
             options.push(shortcut.into());
         }
         if !&val.custom_kbs.is_empty() {
@@ -200,7 +200,7 @@ impl Rofi {
                                 .as_bytes(),
                         );
                     } else {
-                        str.extend_from_slice(format!("\0icon\x1f{}", icon).as_bytes());
+                        str.extend_from_slice(format!("\0icon\x1f{icon}").as_bytes());
                     }
                 }
                 str.push(b'\n');
@@ -261,14 +261,14 @@ impl RofiEntry for ClipHistEntry {
     fn icon(&self) -> Option<String> {
         match self {
             ClipHistEntry::Text { .. } => None,
-            ClipHistEntry::Image { id, content_type } => Some(format!("{}.{}", id, content_type)),
+            ClipHistEntry::Image { id, content_type } => Some(format!("{id}.{content_type}")),
         }
     }
     fn label(&self) -> String {
         match self {
             ClipHistEntry::Text { title, .. } => title.into(),
             ClipHistEntry::Image { id, content_type } => {
-                format!("{}.{}", id, content_type)
+                format!("{id}.{content_type}")
             }
         }
     }

--- a/src/rofi/cliphist_mode.rs
+++ b/src/rofi/cliphist_mode.rs
@@ -238,7 +238,7 @@ impl ClipHistMode {
     }
 
     fn theme(mode: Mode) -> Vec<String> {
-        trace!("Switching theme to {:?}", mode);
+        trace!("Switching theme to {mode:?}");
 
         match mode {
         Mode::Text => vec![

--- a/src/rofi/cliphist_mode.rs
+++ b/src/rofi/cliphist_mode.rs
@@ -18,6 +18,15 @@ enum Mode {
     Image,
 }
 
+/// Configuration for the ClipHistMode
+pub struct ClipHistModeConfig {
+    pub text_mode: config::ModeConfig,
+    pub image_mode: config::ModeConfig,
+    pub delete_mode: config::ModeConfig,
+    pub delete_previous_mode: config::ModeConfig,
+    pub delete_next_mode: config::ModeConfig,
+}
+
 /// A rofi "mode" to display the clipboard history
 /// It keeps an internal state and spawns rofi to display the entries
 pub struct ClipHistMode {
@@ -42,11 +51,7 @@ impl ClipHistMode {
         cache: SimpleCache,
         cliphist: ClipHist,
         clipboard: Clipboard,
-        text_mode: config::ModeConfig,
-        image_mode: config::ModeConfig,
-        delete_mode: config::ModeConfig,
-        delete_previous_mode: config::ModeConfig,
-        delete_next_mode: config::ModeConfig,
+        config: ClipHistModeConfig,
     ) -> anyhow::Result<Self> {
         trace!("Creating ClipHistMode");
 
@@ -56,8 +61,8 @@ impl ClipHistMode {
             .into_iter()
             .partition(|e| matches!(e, ClipHistEntry::Text { .. }));
 
-        let delete_shortcut = &delete_mode.shortcut;
-        let delete_description = &delete_mode.description;
+        let delete_shortcut = &config.delete_mode.shortcut;
+        let delete_description = &config.delete_mode.description;
         let instance = Self {
             rofi,
             cache,
@@ -69,10 +74,18 @@ impl ClipHistMode {
                     Self::title(Mode::Text),
                     "",
                     [
-                        KbCustom::new(1, image_mode.shortcut, image_mode.description),
+                        KbCustom::new(1, config.image_mode.shortcut, config.image_mode.description),
                         KbCustom::new(3, delete_shortcut, delete_description),
-                        KbCustom::new(4, &delete_previous_mode.shortcut, &delete_previous_mode.description),
-                        KbCustom::new(5, &delete_next_mode.shortcut, &delete_next_mode.description),
+                        KbCustom::new(
+                            4,
+                            &config.delete_previous_mode.shortcut,
+                            config.delete_previous_mode.description.clone(),
+                        ),
+                        KbCustom::new(
+                            5,
+                            &config.delete_next_mode.shortcut,
+                            config.delete_next_mode.description.clone(),
+                        ),
                     ],
                     Self::theme(Mode::Text),
                 ),
@@ -83,10 +96,18 @@ impl ClipHistMode {
                     Self::title(Mode::Image),
                     "",
                     [
-                        KbCustom::new(2, text_mode.shortcut, text_mode.description),
+                        KbCustom::new(2, config.text_mode.shortcut, config.text_mode.description),
                         KbCustom::new(3, delete_shortcut, delete_description),
-                        KbCustom::new(4, &delete_previous_mode.shortcut, &delete_previous_mode.description),
-                        KbCustom::new(5, &delete_next_mode.shortcut, &delete_next_mode.description),
+                        KbCustom::new(
+                            4,
+                            &config.delete_previous_mode.shortcut,
+                            config.delete_previous_mode.description.clone(),
+                        ),
+                        KbCustom::new(
+                            5,
+                            &config.delete_next_mode.shortcut,
+                            config.delete_next_mode.description.clone(),
+                        ),
                     ],
                     Self::theme(Mode::Image),
                 ),
@@ -153,7 +174,8 @@ impl ClipHistMode {
                             }
                         }
                         14 => {
-                            let entries_to_delete = current.entries.drain(id + 1..).collect::<Vec<_>>();
+                            let entries_to_delete =
+                                current.entries.drain(id + 1..).collect::<Vec<_>>();
                             for entry in entries_to_delete {
                                 self.cliphist.remove(RofiEntry::id(&entry))?;
                             }

--- a/src/rofi/cliphist_mode.rs
+++ b/src/rofi/cliphist_mode.rs
@@ -45,6 +45,8 @@ impl ClipHistMode {
         text_mode: config::ModeConfig,
         image_mode: config::ModeConfig,
         delete_mode: config::ModeConfig,
+        delete_previous_mode: config::ModeConfig,
+        delete_next_mode: config::ModeConfig,
     ) -> anyhow::Result<Self> {
         trace!("Creating ClipHistMode");
 
@@ -69,6 +71,8 @@ impl ClipHistMode {
                     [
                         KbCustom::new(1, image_mode.shortcut, image_mode.description),
                         KbCustom::new(3, delete_shortcut, delete_description),
+                        KbCustom::new(4, &delete_previous_mode.shortcut, &delete_previous_mode.description),
+                        KbCustom::new(5, &delete_next_mode.shortcut, &delete_next_mode.description),
                     ],
                     Self::theme(Mode::Text),
                 ),
@@ -81,6 +85,8 @@ impl ClipHistMode {
                     [
                         KbCustom::new(2, text_mode.shortcut, text_mode.description),
                         KbCustom::new(3, delete_shortcut, delete_description),
+                        KbCustom::new(4, &delete_previous_mode.shortcut, &delete_previous_mode.description),
+                        KbCustom::new(5, &delete_next_mode.shortcut, &delete_next_mode.description),
                     ],
                     Self::theme(Mode::Image),
                 ),
@@ -139,6 +145,18 @@ impl ClipHistMode {
                         12 => {
                             let entry = current.entries.remove(id);
                             self.cliphist.remove(RofiEntry::id(&entry))?;
+                        }
+                        13 => {
+                            let entries_to_delete = current.entries.drain(..id).collect::<Vec<_>>();
+                            for entry in entries_to_delete {
+                                self.cliphist.remove(RofiEntry::id(&entry))?;
+                            }
+                        }
+                        14 => {
+                            let entries_to_delete = current.entries.drain(id + 1..).collect::<Vec<_>>();
+                            for entry in entries_to_delete {
+                                self.cliphist.remove(RofiEntry::id(&entry))?;
+                            }
                         }
                         _ => bail!("Unexpected key: {}", key),
                     }


### PR DESCRIPTION
This commit introduces two new functionalities to :
- **Delete previous (Alt+p):** Deletes all clipboard entries older than the currently highlighted one.
- **Delete next (Alt+n):** Deletes all clipboard entries newer than the currently highlighted one.

Linting issues are fixed now.
