### PR TITLE
feat: add --theme CLI flag to override rofi theme

### DIFF
--- a/src/bin/rofi-cliphist.rs
+++ b/src/bin/rofi-cliphist.rs
@@ -30,10 +30,15 @@ struct Args {
     /// Sets a custom config file
     #[arg(short = 'f', long, value_name = "FILE")]
     config: Option<PathBuf>,
+
+    /// Sets a custom theme
+    #[arg(short = 't', long, value_name = "THEME")]
+    theme: Option<PathBuf>,
 }
 
 fn main() -> anyhow::Result<()> {
-    let args = Args::parse();
+    let mut args = Args::parse();
+    let theme = args.theme.take();
 
     simple_logger::init_with_level(args.verbose.log_level().unwrap_or(Level::Error))?;
 
@@ -63,7 +68,7 @@ fn main() -> anyhow::Result<()> {
     let cliphist = cliphist::new(cfg.cliphist.path);
     let cache = cache::SimpleCache::new("rofi-cliphist/thumbs-new").expect("Error creating cache");
     let clipboard = clipboard::new(cfg.clipboard.path);
-    let rofi = rofi::new(cfg.rofi.path);
+    let rofi = rofi::new(cfg.rofi.path, theme);
 
     debug!("Starting ClipHistMode");
 
@@ -84,7 +89,11 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn merge_args_into_config(cfg: &mut config::Config, args: Args) {
-    cfg.rofi.path = args.rofi_path.unwrap_or(cfg.rofi.path.clone());
-    cfg.clipboard.path = args.clipboard_path.unwrap_or(cfg.clipboard.path.clone());
-    cfg.cliphist.path = args.cliphist_path.unwrap_or(cfg.cliphist.path.clone());
+    cfg.rofi.path = args.rofi_path.unwrap_or_else(|| cfg.rofi.path.clone());
+    cfg.clipboard.path = args
+        .clipboard_path
+        .unwrap_or_else(|| cfg.clipboard.path.clone());
+    cfg.cliphist.path = args
+        .cliphist_path
+        .unwrap_or_else(|| cfg.cliphist.path.clone());
 }

--- a/src/rofi.rs
+++ b/src/rofi.rs
@@ -154,13 +154,13 @@ impl From<&RofiOptions> for Vec<String> {
             options.push("-p".into());
             options.push(prompt.into());
         }
-        for theme_str in &val.theme_str {
-            options.push("-theme-str".into());
-            options.push(theme_str.into());
-        }
         if let Some(theme) = &val.theme {
             options.push("-theme".into());
             options.push(theme.to_string_lossy().into_owned());
+        }
+        for theme_str in &val.theme_str {
+            options.push("-theme-str".into());
+            options.push(theme_str.into());
         }
 
         options

--- a/src/rofi.rs
+++ b/src/rofi.rs
@@ -1,6 +1,7 @@
 use std::{
     io::{Read, Write},
     os::unix::process::ExitStatusExt,
+    path::PathBuf,
     process::{Command, Stdio},
 };
 
@@ -35,6 +36,7 @@ pub enum RofiResult {
 /// API to interact with rofi using command execution.
 pub struct Rofi {
     pub bin: String,
+    pub theme: Option<PathBuf>,
 }
 
 /// Options to configure rofi when spawning it.
@@ -48,6 +50,7 @@ pub struct RofiOptions {
     pub prompt: Option<String>,
     pub selected_row: usize,
     pub theme_str: Vec<String>,
+    pub theme: Option<PathBuf>,
 }
 
 /// Custom keyboard shortcuts for rofi.
@@ -70,6 +73,7 @@ impl Default for RofiOptions {
             prompt: None,
             selected_row: 0,
             theme_str: vec![],
+            theme: None,
         }
     }
 }
@@ -80,6 +84,7 @@ impl RofiOptions {
         mesg: impl Into<String>,
         custom_kbs: K,
         theme_str: I,
+        theme: Option<PathBuf>,
     ) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -92,6 +97,7 @@ impl RofiOptions {
             prompt: Some(prompt.into()),
             custom_kbs: custom_kbs.into_iter().collect::<Vec<_>>(),
             theme_str: theme_str.into_iter().map(|s| s.into()).collect::<Vec<_>>(),
+            theme,
             ..Default::default()
         }
     }
@@ -152,6 +158,11 @@ impl From<&RofiOptions> for Vec<String> {
             options.push("-theme-str".into());
             options.push(theme_str.into());
         }
+        if let Some(theme) = &val.theme {
+            options.push("-theme".into());
+            options.push(theme.to_string_lossy().into_owned());
+        }
+
         options
     }
 }
@@ -274,6 +285,9 @@ impl RofiEntry for ClipHistEntry {
     }
 }
 
-pub fn new(bin: impl Into<String>) -> Rofi {
-    Rofi { bin: bin.into() }
+pub fn new(bin: impl Into<String>, theme: Option<PathBuf>) -> Rofi {
+    Rofi {
+        bin: bin.into(),
+        theme,
+    }
 }

--- a/src/rofi/cliphist_mode.rs
+++ b/src/rofi/cliphist_mode.rs
@@ -64,10 +64,6 @@ impl ClipHistMode {
         let delete_shortcut = &config.delete_mode.shortcut;
         let delete_description = &config.delete_mode.description;
         let instance = Self {
-            rofi,
-            cache,
-            cliphist,
-            clipboard,
             txt: RofiState {
                 entries: txt,
                 options: RofiOptions::new(
@@ -88,6 +84,7 @@ impl ClipHistMode {
                         ),
                     ],
                     Self::theme(Mode::Text),
+                    rofi.theme.clone(),
                 ),
             },
             img: RofiState {
@@ -110,8 +107,13 @@ impl ClipHistMode {
                         ),
                     ],
                     Self::theme(Mode::Image),
+                    rofi.theme.clone(),
                 ),
             },
+            rofi,
+            cache,
+            cliphist,
+            clipboard,
             mode: Mode::Text,
         };
 


### PR DESCRIPTION
Fixes https://github.com/szaffarano/rofi-tools/issues/78


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive CLI/config plumbing that only changes how the rofi command is invoked when `--theme` is provided.
> 
> **Overview**
> Adds a `--theme`/`-t` CLI flag to `rofi-cliphist` to let users override the rofi theme file at runtime.
> 
> Plumbs the optional theme through `rofi::new` into `RofiOptions` so rofi is launched with `-theme <path>` for both text and image modes, without changing existing config-file theme-str behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf2ed654800ae1b4cea89d076b4f7cbcdeb75482. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->