### PR TITLE
docs: document --theme flag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Options:
   -c, --cliphist-path <CLIPHIST_PATH>    Path to cliphist executable [default: cliphist]
   -w, --clipboard-path <CLIPBOARD_PATH>  Path to wl-copy executable [default: wl-copy]
   -f, --config <FILE>                    Sets a custom config file
+  -t, --theme <THEME>                    Sets a custom theme
   -h, --help                             Print help
   -V, --version                          Print version
 ```


### PR DESCRIPTION
Forget to update the readme with https://github.com/szaffarano/rofi-tools/pull/79 🤦🏼 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it just updates the README usage text and does not affect runtime behavior.
> 
> **Overview**
> Updates the `README.md` CLI usage section for `rofi-cliphist` to include the `-t, --theme <THEME>` option, documenting the ability to supply a custom theme via a command-line flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8dfcb2208561d7d10b0721b18af4a743327210c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->